### PR TITLE
feat: Review API に OpenAI 呼び出しと diff サイズ制限を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "15.4.4",
+        "openai": "^5.12.2",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },
@@ -5958,6 +5959,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
+      "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7208,7 +7230,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -10,24 +10,25 @@
     "test": "jest"
   },
   "dependencies": {
+    "next": "15.4.4",
+    "openai": "^5.12.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.4"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest": "^29.5.3",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.3",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/jest-dom": "^6.0.0",
     "jest-environment-jsdom": "^29.7.0",
+    "node-mocks-http": "^1.17.2",
+    "tailwindcss": "^4",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
-    "node-mocks-http": "^1.17.2"
+    "typescript": "^5"
   }
 }

--- a/pages/api/review.ts
+++ b/pages/api/review.ts
@@ -1,11 +1,68 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import OpenAI from 'openai';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+const MAX_DIFF_CHARS = 200_000;
+
+async function fetchDiff(prUrl: string): Promise<string> {
+  const diffUrl = prUrl.endsWith('.diff') ? prUrl : `${prUrl}.diff`;
+  const resp = await fetch(diffUrl);
+  if (!resp.ok) {
+    throw new Error('Failed to fetch diff');
+  }
+  return resp.text();
+}
+
+async function callOpenAI(diff: string): Promise<string[]> {
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const completion = await client.responses.create({
+    model: 'gpt-5',
+    input: `Please review the following diff and provide bullet list of improvements.\n\n${diff}`,
+  });
+  const output = (completion as any).output_text as string | undefined;
+  if (!output) return [];
+  return output
+    .split('\n')
+    .map((line) => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean);
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 
-  // No processing for now
-  res.status(200).json({ ok: true });
+  const { pr_url } = req.body;
+  if (typeof pr_url !== 'string') {
+    return res.status(400).json({ error: 'pr_url is required' });
+  }
+
+  try {
+    const diff = await fetchDiff(pr_url);
+    if (diff.length > MAX_DIFF_CHARS) {
+      return res.status(413).json({ error: 'Diff too large' });
+    }
+
+    let messages: string[] = [];
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        messages = await callOpenAI(diff);
+        break;
+      } catch (err) {
+        if (attempt === 2) throw err;
+        await new Promise((r) => setTimeout(r, Math.pow(2, attempt) * 1000));
+      }
+    }
+
+    const issues = messages.map((message) => ({ message }));
+    return res.status(200).json({ issues });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
 }
+
+export { MAX_DIFF_CHARS };

--- a/tests/api.review.test.ts
+++ b/tests/api.review.test.ts
@@ -1,13 +1,58 @@
-import handler from '../pages/api/review';
 import { createMocks } from 'node-mocks-http';
 
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      responses: {
+        create: jest.fn().mockResolvedValue({
+          output_text: '- Improve logging\n- Add tests',
+        }),
+      },
+    })),
+  };
+});
+
+import handler, { MAX_DIFF_CHARS } from '../pages/api/review';
+
 describe('POST /api/review', () => {
-  it('returns ok', async () => {
-    const { req, res } = createMocks({ method: 'POST' });
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = 'test';
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => 'diff content',
+    });
+  });
+
+  it('OpenAI の指摘を issues 配列として返す', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { pr_url: 'https://github.com/a/b/pull/1' },
+    });
 
     await handler(req as any, res as any);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData()).toEqual({ ok: true });
+    expect(res._getJSONData()).toEqual({
+      issues: [
+        { message: 'Improve logging' },
+        { message: 'Add tests' },
+      ],
+    });
+  });
+
+  it('diff が上限を超える場合は 413 を返す', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => 'a'.repeat(MAX_DIFF_CHARS + 1),
+    });
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { pr_url: 'https://github.com/a/b/pull/1' },
+    });
+
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(413);
   });
 });


### PR DESCRIPTION
## 概要
- Review API で GitHub の diff を取得して OpenAI に送信
- diff が 200,000 文字を超える場合は 413 を返すガードを実装
- 上記機能を検証するユニットテストを追加

## テスト
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb508d808833186303b0a736d76f2