### PR TITLE
Add GitHub OAuth flow

### DIFF
--- a/pages/api/auth/callback.ts
+++ b/pages/api/auth/callback.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { code } = req.query;
+  if (!code || typeof code !== 'string') {
+    res.status(400).json({ error: 'Code is required' });
+    return;
+  }
+
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    res.status(500).json({ error: 'OAuth client not configured' });
+    return;
+  }
+
+  const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code
+    })
+  });
+
+  if (!tokenRes.ok) {
+    const text = await tokenRes.text();
+    res.status(500).json({ error: text });
+    return;
+  }
+
+  const data = await tokenRes.json();
+  res.status(200).json({ access_token: data.access_token });
+}

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    res.status(500).json({ error: 'GITHUB_CLIENT_ID is not set' });
+    return;
+  }
+
+  const redirectUri = process.env.GITHUB_REDIRECT_URI || 'http://localhost:3000/api/auth/callback';
+  const scope = 'public_repo';
+  const url =
+    `https://github.com/login/oauth/authorize?client_id=${clientId}` +
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&scope=${scope}`;
+
+  res.writeHead(302, { Location: url });
+  res.end();
+}

--- a/tests/api.oauth.test.ts
+++ b/tests/api.oauth.test.ts
@@ -1,0 +1,36 @@
+import loginHandler from '../pages/api/auth/login';
+import callbackHandler from '../pages/api/auth/callback';
+import { createMocks } from 'node-mocks-http';
+
+describe('GitHub OAuth flow', () => {
+  const OLD_ENV = process.env;
+  beforeEach(() => {
+    process.env = { ...OLD_ENV, GITHUB_CLIENT_ID: 'id', GITHUB_CLIENT_SECRET: 'secret', GITHUB_REDIRECT_URI: 'http://localhost/callback' };
+  });
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.resetAllMocks();
+  });
+
+  it('redirects to GitHub and exchanges code for token', async () => {
+    const { req: loginReq, res: loginRes } = createMocks({ method: 'GET' });
+    await loginHandler(loginReq as any, loginRes as any);
+    expect(loginRes._getStatusCode()).toBe(302);
+    const redirectUrl = loginRes._getHeaders().location as string;
+    expect(redirectUrl).toContain('client_id=id');
+    expect(redirectUrl).toContain('scope=public_repo');
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'token' })
+    });
+    (global as any).fetch = mockFetch;
+
+    const { req: cbReq, res: cbRes } = createMocks({ method: 'GET', query: { code: 'abc' } });
+    await callbackHandler(cbReq as any, cbRes as any);
+
+    expect(mockFetch).toHaveBeenCalledWith('https://github.com/login/oauth/access_token', expect.any(Object));
+    expect(cbRes._getStatusCode()).toBe(200);
+    expect(cbRes._getJSONData()).toEqual({ access_token: 'token' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement OAuth endpoints for GitHub with public_repo scope
- add tests verifying authorization redirect and token exchange

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint setup warning)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb4174a08331822ab1b00f2092b6